### PR TITLE
add emotion typing

### DIFF
--- a/.storybook/PropTypesTable/ReactTableContainer.tsx
+++ b/.storybook/PropTypesTable/ReactTableContainer.tsx
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 
 export default styled('div')`
   .ReactTable {

--- a/src/AppBar/DropdownMenu.tsx
+++ b/src/AppBar/DropdownMenu.tsx
@@ -19,11 +19,11 @@
 
 import React, { LiHTMLAttributes } from 'react';
 import { css } from '@emotion/core';
-import styled from '@emotion/styled';
 import clsx from 'clsx';
+import { styled } from '../ThemeProvider';
 
 const Ul = styled('ul')`
-  ${({ theme }) => css(theme.typography.paragraph)};
+  ${({ theme }) => css(theme.typography.paragraph as any)};
   position: absolute;
   background-color: ${({ theme }) => theme.colors.grey_4};
   left: 0;

--- a/src/AppBar/styledComponents.tsx
+++ b/src/AppBar/styledComponents.tsx
@@ -18,7 +18,7 @@
  */
 
 import React from 'react';
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import { withProps } from 'recompose';
 
 import { Typography } from '../Typography';

--- a/src/Button/GoogleLogin/index.tsx
+++ b/src/Button/GoogleLogin/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import css from '@emotion/css';
-import styled from '@emotion/styled';
+import { styled } from '../../ThemeProvider';
 import React from 'react';
 import urlJoin from 'url-join';
 import { Icon } from '../../Icon';

--- a/src/Button/styled.tsx
+++ b/src/Button/styled.tsx
@@ -18,7 +18,7 @@
  */
 
 import { css } from '@emotion/core';
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import { FocusWrapper } from 'src/FocusWrapper';
 
 export const StyledButton = styled<
@@ -29,7 +29,7 @@ export const StyledButton = styled<
     disabled: boolean;
   }
 >(FocusWrapper)`
-  ${({ theme }) => css(theme.typography.default)};
+  ${({ theme }) => css(theme.typography.default as any)};
   transition: all 0.25s;
   display: flex;
   align-items: center;

--- a/src/ClipboardCopyField/index.tsx
+++ b/src/ClipboardCopyField/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { css } from '@emotion/core';
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import React from 'react';
 import { Button } from 'src/Button';
 import { INPUT_SIZES, INPUT_STATES, StyledInputWrapper } from 'src/form/common';

--- a/src/Container/index.tsx
+++ b/src/Container/index.tsx
@@ -19,7 +19,7 @@
 
 import React from 'react';
 import { css } from '@emotion/core';
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import isPropValid from '@emotion/is-prop-valid';
 
 import color from 'color';

--- a/src/ContentMenu/index.tsx
+++ b/src/ContentMenu/index.tsx
@@ -19,7 +19,7 @@
 
 import React from 'react';
 import { Typography } from 'src/Typography';
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import { css } from '@emotion/core';
 
 const Cont = styled('div')`

--- a/src/ContentPlaceholder/index.tsx
+++ b/src/ContentPlaceholder/index.tsx
@@ -19,7 +19,7 @@
 
 import React from 'react';
 import { css } from '@emotion/core';
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 
 import noDataSvg from 'src/assets/noData.svg';
 import { Typography } from '../Typography';

--- a/src/DnaLoader/index.tsx
+++ b/src/DnaLoader/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import css from '@emotion/css';
-import styled from '@emotion/styled-base';
+import { styled } from '../ThemeProvider';
 import range from 'lodash/range';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/DropdownPanel/index.tsx
+++ b/src/DropdownPanel/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { css } from '@emotion/core';
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import debounce from 'lodash/debounce';
 import React, { RefObject, useEffect, useRef, useState } from 'react';
 import { Button } from 'src/Button';

--- a/src/FocusWrapper/index.tsx
+++ b/src/FocusWrapper/index.tsx
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import styled from '@emotion/styled-base';
+import { styled } from '../ThemeProvider';
 
 export const FocusWrapper = styled('button')`
   border: none;

--- a/src/Footer/index.tsx
+++ b/src/Footer/index.tsx
@@ -19,7 +19,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import { Icon } from '../Icon';
 import icgcLogo from '../assets/icgc_logo.svg';
 import css from '@emotion/css';
@@ -27,7 +27,7 @@ import { Row, Col } from 'react-grid-system';
 import { Link as A } from '../Link';
 
 const Container = styled('footer')`
-  ${({ theme }) => css(theme.typography.paragraph)};
+  ${({ theme }) => css(theme.typography.paragraph as any)};
   font-size: 11px;
   min-height: 58px;
 

--- a/src/InstructionBox/index.tsx
+++ b/src/InstructionBox/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { css } from '@emotion/core';
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import React from 'react';
 import { Col, Row, ScreenClassRender } from 'react-grid-system';
 import { useTheme } from 'src/ThemeProvider';

--- a/src/Link/index.tsx
+++ b/src/Link/index.tsx
@@ -19,7 +19,7 @@
 
 import React, { AnchorHTMLAttributes } from 'react';
 import { css } from '@emotion/core';
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 
 type LinkVariant = 'INLINE' | 'BLOCK';
 export type HyperLinkProps = {
@@ -33,7 +33,7 @@ export type HyperLinkProps = {
 } & AnchorHTMLAttributes<HTMLAnchorElement>;
 
 const StyledLink = styled<'a', HyperLinkProps>('a')`
-  ${({ theme }) => css(theme.typography.default)}
+  ${({ theme }) => css(theme.typography.default as any)}
   cursor: pointer;
   color: ${({ theme, invert }) => (invert ? theme.colors.white : theme.colors.accent2_dark)};
   text-decoration: ${({ underline }) => (underline ? 'underline' : 'none')};

--- a/src/MailTo/index.tsx
+++ b/src/MailTo/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import React from 'react';
-import { styled } from '..';
+import { styled } from '../ThemeProvider';
 import { Typography } from '../Typography';
 
 const Mail = styled('a')`

--- a/src/Modal/index.tsx
+++ b/src/Modal/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { css } from '@emotion/core';
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import Color from 'color';
 import React from 'react';
 import { BUTTON_SIZES, BUTTON_VARIANTS } from 'src/Button/constants';

--- a/src/NumberRangeField/common.tsx
+++ b/src/NumberRangeField/common.tsx
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { styled } from 'src';
+import { styled } from '../ThemeProvider';
 
 export const FieldInputWrapper = styled('div')`
   width: 35%;

--- a/src/PageLayout/index.tsx
+++ b/src/PageLayout/index.tsx
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import { Container } from '../Container';
 
 export const PageContainer = styled('div')`

--- a/src/Pipe/index.tsx
+++ b/src/Pipe/index.tsx
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import defaultTheme from 'src/theme/defaultTheme';
 
 const PipeContainer = styled('div')`

--- a/src/Progress/index.tsx
+++ b/src/Progress/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { css } from '@emotion/core';
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import React from 'react';
 import { Icon } from '../Icon';
 
@@ -111,7 +111,7 @@ const Separator = styled<'div', { state: ProgressStatus }>('div')`
 `;
 
 const Text = styled('div')<{ completed: boolean; state: ProgressStatus }>`
-  ${({ theme }) => theme.typography.caption};
+  ${({ theme }) => theme.typography.caption as any};
   font-weight: ${({ completed }) => (completed ? 600 : 'normal')};
   color: ${({ theme, state }) => (state === 'locked' ? theme.colors.grey : theme.colors.black)};
 `;

--- a/src/SubMenu/index.tsx
+++ b/src/SubMenu/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import css from '@emotion/css';
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import React from 'react';
 import { Input } from '../form/Input';
 import { Icon } from '../Icon';

--- a/src/SubMenu/styledComponents.tsx
+++ b/src/SubMenu/styledComponents.tsx
@@ -18,7 +18,7 @@
  */
 
 import css from '@emotion/css';
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import defaultTheme from 'src/theme/defaultTheme';
 
 type StyleCalculationInput = {
@@ -65,11 +65,11 @@ const level1Style = ({ selected, theme }: StyleCalculationInput) => css`
   & > .FacetContentSlim .MenuItemContent {
     padding: 6px;
     border-bottom: 1px solid;
-        border-color: ${theme.colors.grey_2};
+    border-color: ${theme.colors.grey_2};
   }
   & a {
     text-decoration: underline;
-    font-weight:normal;
+    font-weight: normal;
   }
 `;
 
@@ -139,7 +139,7 @@ export const IconContainer = styled('span')`
 `;
 
 export const ContentContainer = styled('button')<{ as?: keyof JSX.IntrinsicElements }>`
-  ${({ theme }) => css(theme.typography.default)};
+  ${({ theme }) => css(theme.typography.default as any)};
   border: none;
   width: 100%;
   padding: 0px 2px 0px 0px;

--- a/src/Table/TablePagination/index.tsx
+++ b/src/Table/TablePagination/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import css from '@emotion/css';
-import styled from '@emotion/styled';
+import { styled } from '../../ThemeProvider';
 import ceil from 'lodash/ceil';
 import floor from 'lodash/floor';
 import range from 'lodash/range';
@@ -81,7 +81,7 @@ const DoubleArrow: React.ComponentType<{ transform?: string }> = ({ transform })
 );
 
 const A = styled('a')`
-  ${({ theme }) => css(theme.typography.data)};
+  ${({ theme }) => theme.typography.data as any};
   background-color: #fff;
   border-radius: 50%;
   cursor: pointer;

--- a/src/Table/styledComponent.tsx
+++ b/src/Table/styledComponent.tsx
@@ -18,7 +18,7 @@
  */
 
 import React from 'react';
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import css from '@emotion/css';
 import ReactTable from 'react-table';
 
@@ -98,7 +98,7 @@ export const StyledTable = styled<typeof ReactTable, StyledTableProps>(ReactTabl
   }
 
   &.ReactTable .rt-thead.-header .rt-tr .rt-th {
-    ${({ theme }) => css(theme.typography.data)};
+    ${({ theme }) => css(theme.typography.data as any)};
     min-height: 28px;
     line-height: 1.33;
     font-weight: bold;
@@ -110,7 +110,7 @@ export const StyledTable = styled<typeof ReactTable, StyledTableProps>(ReactTabl
   }
 
   &.ReactTable .rt-thead.-headerGroups {
-    ${({ theme }) => css(theme.typography.data)};
+    ${({ theme }) => css(theme.typography.data as any)};
     background: ${({ theme }) => theme.colors.grey_2};
     font-weight: 600;
     font-size: 13px;
@@ -118,7 +118,7 @@ export const StyledTable = styled<typeof ReactTable, StyledTableProps>(ReactTabl
   }
 
   &.ReactTable .rt-tbody .rt-td {
-    ${({ theme }) => css(theme.typography.data)}
+    ${({ theme }) => css(theme.typography.data as any)}
     min-height: 28px;
     line-height: 1.33;
     padding: 2px 8px;

--- a/src/Tabs/index.tsx
+++ b/src/Tabs/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import css from '@emotion/css';
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import clsx from 'clsx';
 import React from 'react';
 import useTheme from '../utils/useTheme';
@@ -26,7 +26,7 @@ import useTheme from '../utils/useTheme';
 const TabsContext = React.createContext({ onChange: null, value: null });
 
 export const TabButton = styled<'button', { as?: keyof HTMLElementTagNameMap }>('button')`
-  ${({ theme }) => css(theme.typography.label)};
+  ${({ theme }) => css(theme.typography.label as any)};
   color: ${({ theme }) => theme.colors.grey};
   display: flex;
   border: 0;

--- a/src/Tag/index.tsx
+++ b/src/Tag/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import css from '@emotion/css';
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 
 type TagVariant =
   | 'DISABLED'

--- a/src/ThemeProvider/index.tsx
+++ b/src/ThemeProvider/index.tsx
@@ -20,6 +20,8 @@
 import * as React from 'react';
 import { ThemeProvider as EmotionThemeProvider } from 'emotion-theming';
 import { ThemeContext } from '@emotion/core';
+import { default as emotionStyled, CreateStyled } from '@emotion/styled';
+
 import PropTypes from 'prop-types';
 
 import defaultTheme from '../theme/defaultTheme';
@@ -45,3 +47,6 @@ const ThemeProvider: React.ComponentType<{ theme?: keyof typeof themes }> = ({
 
 export default ThemeProvider;
 export const useTheme = () => React.useContext(ThemeContext as React.Context<typeof defaultTheme>);
+export const styled: CreateStyled<typeof defaultTheme> = emotionStyled;
+
+export type Theme = typeof defaultTheme;

--- a/src/TitleBar/index.tsx
+++ b/src/TitleBar/index.tsx
@@ -18,14 +18,14 @@
  */
 
 import css from '@emotion/css';
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import React from 'react';
 import { Icon } from '../Icon';
 import useTheme from '../utils/useTheme';
 
 const Nav = styled('nav')`
   padding: 18px 29px 18px 0;
-  ${({ theme }) => css(theme.typography.title)};
+  ${({ theme }) => css(theme.typography.title as any)};
   & a {
     color: ${({ theme }) => theme.titleBar.linkColor};
     text-decoration: none;
@@ -42,7 +42,7 @@ const Ol = styled('ol')`
 
 const Li = styled('li')`
   list-style: none;
-  ${({ theme }) => css(theme.typography.title)};
+  ${({ theme }) => css(theme.typography.title as any)};
 `;
 
 const Sep = styled('li')`

--- a/src/TitleBorder/index.tsx
+++ b/src/TitleBorder/index.tsx
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import defaultTheme from 'src/theme/defaultTheme';
 
 export const TitleBorder = styled<

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -19,7 +19,7 @@
 
 // @flow
 import { css, Global } from '@emotion/core';
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import { merge } from 'lodash';
 import * as React from 'react';
 import { Tooltip as ReactTippy, TooltipProps as TippyProps } from 'react-tippy';
@@ -81,9 +81,8 @@ export const Tooltip: React.ComponentType<TooltipProps> = ({
     padding: 2px 4px;
     color: white;
     font-weight: normal;
-    ${
-      arrow &&
-      `
+    ${arrow &&
+    `
       &:before {
         content: '';
         display: block;
@@ -94,8 +93,7 @@ export const Tooltip: React.ComponentType<TooltipProps> = ({
         pointer-events: none;
         ${arrowStyles[position]}
       }
-    `
-    }
+    `}
   `;
 
   return (

--- a/src/Typography/index.tsx
+++ b/src/Typography/index.tsx
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import memoize from 'lodash/memoize';
 import * as React from 'react';
 import defaultTheme from '../theme/defaultTheme';

--- a/src/VerticalTabs/index.tsx
+++ b/src/VerticalTabs/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { css } from '@emotion/core';
-import styled from '@emotion/styled';
+import { styled } from '../ThemeProvider';
 import React, { HTMLAttributes, HtmlHTMLAttributes, MouseEventHandler, ReactNode } from 'react';
 import { FocusWrapper } from 'src/FocusWrapper';
 import { Tag } from 'src/Tag';

--- a/src/form/Checkbox/index.tsx
+++ b/src/form/Checkbox/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import React, { RefObject } from 'react';
-import styled from '@emotion/styled';
+import { styled } from '../../ThemeProvider';
 
 /**
  * Checkbox styles

--- a/src/form/FormHelperText/index.tsx
+++ b/src/form/FormHelperText/index.tsx
@@ -19,7 +19,7 @@
 
 import React from 'react';
 import { FormControlContext } from '../FormControl/FormControlContext';
-import styled from '@emotion/styled';
+import { styled } from '../../ThemeProvider';
 import clsx from 'clsx';
 import css from '@emotion/css';
 import pick from 'lodash/pick';
@@ -52,7 +52,7 @@ export const FormHelperText = React.forwardRef<
   } = props;
 
   const StyledComponent = styled<any, any>(Component)`
-    ${({ theme }) => css(theme.typography.caption)};
+    ${({ theme }) => css(theme.typography.caption as any)};
     margin: 3px 7px;
     line-height: 14px;
 

--- a/src/form/Input/styledComponents.tsx
+++ b/src/form/Input/styledComponents.tsx
@@ -17,12 +17,12 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import styled from '@emotion/styled';
+import { styled } from '../../ThemeProvider';
 import { css } from '@emotion/core';
 export { StyledInputWrapper } from '../common';
 
 export const StyledInput = styled<'input', { inputSize: string }>('input')`
-  ${({ theme }) => css(theme.typography.default)};
+  ${({ theme }) => css(theme.typography.default as any)};
   padding: ${({ theme, inputSize }) => theme.input.paddings[inputSize]};
   border: none;
   outline: none;

--- a/src/form/InputLabel/index.tsx
+++ b/src/form/InputLabel/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import css from '@emotion/css';
-import styled from '@emotion/styled';
+import { styled } from '../../ThemeProvider';
 import clsx from 'clsx';
 import get from 'lodash/get';
 import pick from 'lodash/pick';
@@ -40,7 +40,7 @@ export const InputLabel = React.forwardRef<
   const { className: classNameProp, children, ...other } = props;
 
   const Label = styled('label')`
-    ${({ theme }) => css(theme.typography.label)};
+    ${({ theme }) => css(theme.typography.label as any)};
     margin-top: 7px;
     &.disabled {
     }

--- a/src/form/MultiSelect/Option.tsx
+++ b/src/form/MultiSelect/Option.tsx
@@ -19,11 +19,11 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from '@emotion/styled';
+import { styled } from '../../ThemeProvider';
 import css from '@emotion/css';
 
 const Li = styled('li')`
-  ${({ theme }) => css(theme.typography.data)};
+  ${({ theme }) => css(theme.typography.data as any)};
   list-style: none;
   padding-left: 7px;
   font-family: ${({ theme }) => theme.typography.paragraph.fontFamily};

--- a/src/form/MultiSelect/index.tsx
+++ b/src/form/MultiSelect/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import css from '@emotion/css';
-import styled from '@emotion/styled';
+import { styled } from '../../ThemeProvider';
 import clsx from 'clsx';
 import compact from 'lodash/compact';
 import find from 'lodash/find';
@@ -100,7 +100,7 @@ const InputBox = styled(StyledInputWrapper)`
 `;
 
 const Input = styled<'input', { autoComplete: string; single?: boolean }>('input')`
-  ${({ theme }) => css(theme.typography.default)};
+  ${({ theme }) => css(theme.typography.default as any)};
   background-color: transparent;
   border: none;
   display: block;
@@ -113,7 +113,7 @@ const Input = styled<'input', { autoComplete: string; single?: boolean }>('input
 `;
 
 const PlaceHolder = styled('span')`
-  ${({ theme }) => css(theme.typography.data)};
+  ${({ theme }) => css(theme.typography.data as any)};
   color: ${({ theme }) => theme.multiSelect.placeHolderColor};
   position: absolute;
   pointer-events: none;

--- a/src/form/Radio/index.tsx
+++ b/src/form/Radio/index.tsx
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import styled from '@emotion/styled';
+import { styled } from '../../ThemeProvider';
 import React from 'react';
 
 /*

--- a/src/form/Select/styledComponents.tsx
+++ b/src/form/Select/styledComponents.tsx
@@ -18,11 +18,10 @@
  */
 
 import React from 'react';
-import styled from '@emotion/styled';
 import { withProps } from 'recompose';
-
 import { Icon } from '../../Icon';
 import { Typography } from '../../Typography';
+import { styled } from '../../ThemeProvider';
 
 export type PopupPosition = 'UP' | 'DOWN';
 export const POPUP_POSITIONS = { UP: 'UP' as PopupPosition, DOWN: 'DOWN' as PopupPosition };

--- a/src/form/common.tsx
+++ b/src/form/common.tsx
@@ -17,14 +17,9 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
-import { Row, Col } from 'react-grid-system';
-import { Typography } from '../Typography';
-import React from 'react';
-
 import { INPUT_STATES as INPUT_THEME_STATES } from '../theme/defaultTheme/input';
+import { styled } from '../ThemeProvider';
 
 export type InputSize = 'sm' | 'lg';
 
@@ -111,7 +106,7 @@ export const RadioCheckboxWrapper = styled<'div', RadioCheckboxWrapperProps>('di
   padding: 4px 6px 4px 8px;
 
   label {
-    ${({ theme }) => css(theme.typography.paragraph)};
+    ${({ theme }) => css(theme.typography.paragraph as any)};
     line-height: normal;
     position: relative;
     cursor: pointer;

--- a/src/notifications/Notification/styledComponents.tsx
+++ b/src/notifications/Notification/styledComponents.tsx
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import styled from '@emotion/styled';
+import { styled } from '../../ThemeProvider';
 import { FocusWrapper } from '../../FocusWrapper';
 import { NotificationVariant, NOTIFICATION_VARIANTS } from './index';
 


### PR DESCRIPTION
**Description of changes**

fixes Emotion type checking for working build
- adds valid typing for theme in styled function calls
- types invalid css function usage as `any`
  - not ideal but it's how we've tackled this already, usage will need to modified in future, less breaking change by adding type fix

**Type of Change**

- [ ] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [ ] No new UIKit components or changes
- [ ] Feature is minimally responsive
- [ ] Manual testing of UI feature
- [ ] Add copyrights to new files
- [ ] Connected ticket to PR
