### PR TITLE
Fixing imports in the published UIKit

### DIFF
--- a/.storybook/PropTypesTable/ReactTableContainer.tsx
+++ b/.storybook/PropTypesTable/ReactTableContainer.tsx
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../ThemeProvider';
 
 export default styled('div')`
   .ReactTable {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@icgc-argo/uikit",
-  "version": "1.16.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@icgc-argo/uikit",
-      "version": "1.16.0",
+      "version": "2.0.0",
       "dependencies": {
         "@babel/runtime-corejs2": "^7.7.2",
         "@emotion/react": "^11.10.4",
@@ -68,8 +68,8 @@
         "typescript": "^4.6.4"
       },
       "peerDependencies": {
-        "react": "16.x.x || 17.x.x",
-        "react-dom": "16.x.x || 17.x.x"
+        "react": "17.x.x",
+        "react-dom": "17.x.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@icgc-argo/uikit",
   "version": "2.0.0",
   "description": "ARGO UI component library",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/icgc-argo/uikit"
@@ -25,8 +25,8 @@
     "publish-uikit": "cd dist && npm publish --access public"
   },
   "peerDependencies": {
-    "react": "16.x.x || 17.x.x",
-    "react-dom": "16.x.x || 17.x.x"
+    "react": "17.x.x",
+    "react-dom": "17.x.x"
   },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.7.2",

--- a/src/AppBar/DropdownMenu.tsx
+++ b/src/AppBar/DropdownMenu.tsx
@@ -20,7 +20,7 @@
 import React, { LiHTMLAttributes } from 'react';
 import { css } from '@emotion/react';
 import clsx from 'clsx';
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../ThemeProvider';
 
 const Ul = styled('ul')`
   ${({ theme }) => css(theme.typography.paragraph as any)};

--- a/src/AppBar/index.tsx
+++ b/src/AppBar/index.tsx
@@ -20,10 +20,10 @@
 import { css } from '@emotion/react';
 import PropTypes from 'prop-types';
 import React, { PropsWithChildren } from 'react';
-import logo from 'src/assets/logo_white.svg';
-import { Typography } from 'src/Typography';
-import { useClickAway } from 'src/utils/useClickAway';
-import useTheme from 'src/utils/useTheme';
+import logo from '../assets/logo_white.svg';
+import { Typography } from '../Typography';
+import { useClickAway } from '../utils/useClickAway';
+import useTheme from '../utils/useTheme';
 import { DropdownMenuItem } from './DropdownMenu';
 import {
   AppBarContainer,

--- a/src/AppBar/styledComponents.tsx
+++ b/src/AppBar/styledComponents.tsx
@@ -17,10 +17,10 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../ThemeProvider';
 import { withProps } from 'recompose';
 
-import { Typography } from 'src/Typography';
+import { Typography } from '../Typography';
 
 const MenuItemTypography: typeof Typography = withProps(() => ({
   variant: 'navigation',

--- a/src/Button/GoogleLogin/index.tsx
+++ b/src/Button/GoogleLogin/index.tsx
@@ -18,12 +18,12 @@
  */
 
 import { css } from '@emotion/react';
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../../ThemeProvider';
 import React from 'react';
 import urlJoin from 'url-join';
-import { Icon } from 'src/Icon';
-import useTheme from 'src/utils/useTheme';
-import { Button } from 'src/Button';
+import { Icon } from '../../Icon';
+import useTheme from '../../utils/useTheme';
+import { Button } from '../../Button';
 
 /**
  * Social login for Google

--- a/src/Button/index.tsx
+++ b/src/Button/index.tsx
@@ -19,8 +19,8 @@
 
 import { css } from '@emotion/react';
 import React from 'react';
-import { Icon } from 'src/Icon';
-import useTheme from 'src/utils/useTheme';
+import { Icon } from '../Icon';
+import useTheme from '../utils/useTheme';
 import { BUTTON_SIZES, BUTTON_VARIANTS } from './constants';
 import { StyledButton } from './styled';
 import { ButtonSize, ButtonVariant } from './types';

--- a/src/Button/styled.tsx
+++ b/src/Button/styled.tsx
@@ -18,8 +18,8 @@
  */
 
 import { css } from '@emotion/react';
-import { styled } from 'src/ThemeProvider';
-import { FocusWrapper } from 'src/FocusWrapper';
+import { styled } from '../ThemeProvider';
+import { FocusWrapper } from '../FocusWrapper';
 
 export const StyledButton = styled(FocusWrapper)<{
   size: 'sm' | 'md';

--- a/src/ClipboardCopyField/index.tsx
+++ b/src/ClipboardCopyField/index.tsx
@@ -18,13 +18,13 @@
  */
 
 import { css } from '@emotion/react';
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../ThemeProvider';
 import React from 'react';
-import { Button } from 'src/Button';
-import { INPUT_SIZES, INPUT_STATES, StyledInputWrapper } from 'src/form/common';
-import { Icon } from 'src/Icon';
-import { Tag, TAG_VARIANTS } from 'src/Tag';
-import { Typography } from 'src/Typography';
+import { Button } from '../Button';
+import { INPUT_SIZES, INPUT_STATES, StyledInputWrapper } from '../form/common';
+import { Icon } from '../Icon';
+import { Tag, TAG_VARIANTS } from '../Tag';
+import { Typography } from '../Typography';
 
 const TagWrapper = styled('div')`
   margin-right: 5px;

--- a/src/Container/index.tsx
+++ b/src/Container/index.tsx
@@ -19,12 +19,12 @@
 
 import React from 'react';
 import { css } from '@emotion/react';
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../ThemeProvider';
 import isPropValid from '@emotion/is-prop-valid';
 
 import color from 'color';
-import useTheme from 'src/utils/useTheme';
-import { DnaLoader } from 'src/DnaLoader';
+import useTheme from '../utils/useTheme';
+import { DnaLoader } from '../DnaLoader';
 
 const ContainerBackground = styled('div', {
   shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'loading',

--- a/src/ContentMenu/index.tsx
+++ b/src/ContentMenu/index.tsx
@@ -18,8 +18,8 @@
  */
 
 import React from 'react';
-import { Typography } from 'src/Typography';
-import { styled } from 'src/ThemeProvider';
+import { Typography } from '../Typography';
+import { styled } from '../ThemeProvider';
 import { css } from '@emotion/react';
 
 const Cont = styled('div')`

--- a/src/ContentPlaceholder/index.tsx
+++ b/src/ContentPlaceholder/index.tsx
@@ -19,10 +19,10 @@
 
 import React from 'react';
 import { css } from '@emotion/react';
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../ThemeProvider';
 
-import noDataSvg from 'src/assets/noData.svg';
-import { Typography } from 'src/Typography';
+import noDataSvg from '../assets/noData.svg';
+import { Typography } from '../Typography';
 
 const Container = styled('div')`
   display: flex;

--- a/src/DnaLoader/index.tsx
+++ b/src/DnaLoader/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { css } from '@emotion/react';
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../ThemeProvider';
 import range from 'lodash/range';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/DropdownButton/index.tsx
+++ b/src/DropdownButton/index.tsx
@@ -19,10 +19,10 @@
 
 import * as React from 'react';
 import { css, SerializedStyles } from '@emotion/react';
-import { Typography } from 'src/Typography';
-import { Button } from 'src/Button';
-import { useClickAway } from 'src/utils/useClickAway';
-import { useTheme } from 'src/ThemeProvider';
+import { Typography } from '../Typography';
+import { Button } from '../Button';
+import { useClickAway } from '../utils/useClickAway';
+import { useTheme } from '../ThemeProvider';
 
 export const DropdownButtonMenuItem: typeof Typography = (props) => {
   const theme = useTheme();

--- a/src/DropdownPanel/index.tsx
+++ b/src/DropdownPanel/index.tsx
@@ -18,16 +18,16 @@
  */
 
 import { css } from '@emotion/react';
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../ThemeProvider';
 import debounce from 'lodash/debounce';
 import React, { RefObject, useEffect, useRef, useState } from 'react';
-import { Button } from 'src/Button';
-import { Input } from 'src/form/Input';
-import { Icon } from 'src/Icon';
-import { UikitIconNames } from 'src/Icon/icons';
-import { Tag } from 'src/Tag';
-import { Tooltip } from 'src/Tooltip';
-import useTheme from 'src/utils/useTheme';
+import { Button } from '../Button';
+import { Input } from '../form/Input';
+import { Icon } from '../Icon';
+import { UikitIconNames } from '../Icon/icons';
+import { Tag } from '../Tag';
+import { Tooltip } from '../Tooltip';
+import useTheme from '../utils/useTheme';
 
 const FILL_COLOUR = '#0774D3';
 

--- a/src/Facet/NumberRangeFacet/index.tsx
+++ b/src/Facet/NumberRangeFacet/index.tsx
@@ -19,8 +19,8 @@
 
 import { css } from '@emotion/react';
 import React from 'react';
-import { NumberRangeField } from 'src/NumberRangeField';
-import { MenuItem } from 'src/SubMenu';
+import { NumberRangeField } from '../../NumberRangeField';
+import { MenuItem } from '../../SubMenu';
 
 export const NumberRangeFacet = ({
   subMenuName,

--- a/src/Facet/index.tsx
+++ b/src/Facet/index.tsx
@@ -19,8 +19,8 @@
 
 import { css } from '@emotion/react';
 import React from 'react';
-import { OptionsList, OptionsListFilterOption } from 'src/OptionsList';
-import { MenuItem } from 'src/SubMenu';
+import { OptionsList, OptionsListFilterOption } from '../OptionsList';
+import { MenuItem } from '../SubMenu';
 
 export const Facet = ({
   subMenuName,

--- a/src/FileSelectButton/index.tsx
+++ b/src/FileSelectButton/index.tsx
@@ -19,7 +19,7 @@
 
 import React from 'react';
 import { css } from '@emotion/react';
-import { Button } from 'src/Button';
+import { Button } from '../Button';
 
 type FileSelectButtonProps = Omit<React.ComponentProps<typeof Button>, 'onClick'> & {
   inputProps?: Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'>;

--- a/src/FocusWrapper/index.tsx
+++ b/src/FocusWrapper/index.tsx
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../ThemeProvider';
 
 export const FocusWrapper = styled('button')`
   border: none;

--- a/src/Footer/index.tsx
+++ b/src/Footer/index.tsx
@@ -19,12 +19,12 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { styled } from 'src/ThemeProvider';
-import { Icon } from 'src/Icon';
-import icgcLogo from 'src/assets/icgc_logo.svg';
+import { styled } from '../ThemeProvider';
+import { Icon } from '../Icon';
+import icgcLogo from '../assets/icgc_logo.svg';
 import { css } from '@emotion/react';
 import { Row, Col } from 'react-grid-system';
-import { Link as A } from 'src/Link';
+import { Link as A } from '../Link';
 
 const Container = styled('footer')`
   ${({ theme }) => css(theme.typography.paragraph as any)};

--- a/src/Icon/InteractiveIcon/index.tsx
+++ b/src/Icon/InteractiveIcon/index.tsx
@@ -19,10 +19,10 @@
 
 import { css } from '@emotion/react';
 import React from 'react';
-import { Icon } from 'src/Icon';
-import { ThemeColorNames } from 'src/theme/types';
-import { useTheme } from 'src/ThemeProvider';
-import { Tooltip, TooltipProps } from 'src/Tooltip';
+import { Icon } from '../../Icon';
+import { ThemeColorNames } from '../../theme/types';
+import { useTheme } from '../../ThemeProvider';
+import { Tooltip, TooltipProps } from '../../Tooltip';
 
 // dims corresponding hex code for a 25% dim
 const dimColour = (hex: string) => `${hex}BF`;

--- a/src/Icon/index.tsx
+++ b/src/Icon/index.tsx
@@ -20,9 +20,9 @@
 import { css } from '@emotion/react';
 import get from 'lodash/get';
 import React, { SVGAttributes } from 'react';
-import defaultTheme from 'src/theme/defaultTheme';
-import { ThemeColorNames } from 'src/theme/types';
-import useTheme from 'src/utils/useTheme';
+import defaultTheme from '../theme/defaultTheme';
+import { ThemeColorNames } from '../theme/types';
+import useTheme from '../utils/useTheme';
 import { Icons as icons, UikitIconNames } from './icons';
 
 export type Outline = { color: keyof ThemeColorNames | string; width: number };

--- a/src/InstructionBox/index.tsx
+++ b/src/InstructionBox/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { css } from '@emotion/react';
-import { styled, useTheme } from 'src/ThemeProvider';
+import { styled, useTheme } from '../ThemeProvider';
 import React from 'react';
 import { Col, Row, ScreenClassRender } from 'react-grid-system';
 

--- a/src/Legend/index.tsx
+++ b/src/Legend/index.tsx
@@ -19,10 +19,10 @@
 
 import { css, SerializedStyles } from '@emotion/react';
 import React, { createRef, useState } from 'react';
-import { Button } from 'src/Button';
-import { DropdownButtonMenuItem } from 'src/DropdownButton';
-import { Icon } from 'src/Icon';
-import { useTheme } from 'src/ThemeProvider';
+import { Button } from '../Button';
+import { DropdownButtonMenuItem } from '../DropdownButton';
+import { Icon } from '../Icon';
+import { useTheme } from '../ThemeProvider';
 
 type LegendItemConfig<ValueType = string> = {
   value: ValueType;

--- a/src/Link/index.tsx
+++ b/src/Link/index.tsx
@@ -19,7 +19,7 @@
 
 import React, { AnchorHTMLAttributes } from 'react';
 import { css } from '@emotion/react';
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../ThemeProvider';
 
 type LinkVariant = 'INLINE' | 'BLOCK';
 export type HyperLinkProps = {

--- a/src/MailTo/index.tsx
+++ b/src/MailTo/index.tsx
@@ -18,8 +18,8 @@
  */
 
 import React from 'react';
-import { styled } from 'src/ThemeProvider';
-import { Typography } from 'src/Typography';
+import { styled } from '../ThemeProvider';
+import { Typography } from '../Typography';
 
 const Mail = styled('a')`
   color: ${({ theme }) => theme.colors.black};

--- a/src/Modal/index.tsx
+++ b/src/Modal/index.tsx
@@ -18,16 +18,16 @@
  */
 
 import { css } from '@emotion/react';
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../ThemeProvider';
 import Color from 'color';
 import React from 'react';
-import { BUTTON_SIZES, BUTTON_VARIANTS } from 'src/Button/constants';
-import { ButtonSize } from 'src/Button/types';
-import { UikitIconNames } from 'src/Icon/icons';
-import { Button } from 'src/Button';
-import { FocusWrapper } from 'src/FocusWrapper';
-import { Icon } from 'src/Icon';
-import { Typography } from 'src/Typography';
+import { BUTTON_SIZES, BUTTON_VARIANTS } from '../Button/constants';
+import { ButtonSize } from '../Button/types';
+import { UikitIconNames } from '../Icon/icons';
+import { Button } from '../Button';
+import { FocusWrapper } from '../FocusWrapper';
+import { Icon } from '../Icon';
+import { Typography } from '../Typography';
 
 const DefaultFooter = ({
   actionVisible,

--- a/src/NumberRangeField/common.tsx
+++ b/src/NumberRangeField/common.tsx
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../ThemeProvider';
 
 export const FieldInputWrapper = styled('div')`
   width: 35%;

--- a/src/NumberRangeField/index.tsx
+++ b/src/NumberRangeField/index.tsx
@@ -19,10 +19,10 @@
 
 import { css } from '@emotion/react';
 import React from 'react';
-import { Button } from 'src/Button';
-import { Input } from 'src/form/Input';
-import { useTheme } from 'src/ThemeProvider';
-import { Typography } from 'src/Typography';
+import { Button } from '../Button';
+import { Input } from '../form/Input';
+import { useTheme } from '../ThemeProvider';
+import { Typography } from '../Typography';
 import { FieldDescriptionLabel, FieldInputWrapper } from './common';
 
 export const NumberRangeField: React.ComponentType<{

--- a/src/OptionsList/ViewAmountController.tsx
+++ b/src/OptionsList/ViewAmountController.tsx
@@ -18,9 +18,9 @@
  */
 
 import { css } from '@emotion/react';
-import { Icon } from 'src/Icon';
-import { Link as HyperLink } from 'src/Link';
-import { useTheme } from 'src/ThemeProvider';
+import { Icon } from '../Icon';
+import { Link as HyperLink } from '../Link';
+import { useTheme } from '../ThemeProvider';
 
 export const ViewAmountController: React.ComponentType<{
   /** Function to handle what happens when the selectAll/DeselectAll button is clicked */

--- a/src/OptionsList/index.tsx
+++ b/src/OptionsList/index.tsx
@@ -21,11 +21,11 @@ import { css } from '@emotion/react';
 import concat from 'lodash/concat';
 import orderBy from 'lodash/orderBy';
 import React from 'react';
-import { Checkbox } from 'src/form/Checkbox';
-import { Tag } from 'src/Tag';
-import { Tooltip } from 'src/Tooltip';
-import { Typography } from 'src/Typography';
-import useTheme from 'src/utils/useTheme';
+import { Checkbox } from '../form/Checkbox';
+import { Tag } from '../Tag';
+import { Tooltip } from '../Tooltip';
+import { Typography } from '../Typography';
+import useTheme from '../utils/useTheme';
 import { ViewAmountController } from './ViewAmountController';
 
 export type OptionsListFilterOption = {

--- a/src/PageLayout/index.tsx
+++ b/src/PageLayout/index.tsx
@@ -17,8 +17,8 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { styled } from 'src/ThemeProvider';
-import { Container } from 'src/Container';
+import { styled } from '../ThemeProvider';
+import { Container } from '../Container';
 
 export const PageContainer = styled('div')`
   display: grid;

--- a/src/PercentBar/index.tsx
+++ b/src/PercentBar/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { css, keyframes } from '@emotion/react';
-import useTheme from 'src/utils/useTheme';
+import useTheme from '../utils/useTheme';
 
 export const PercentBar: React.ComponentType<{
   num: number;

--- a/src/PercentageBar/index.tsx
+++ b/src/PercentageBar/index.tsx
@@ -19,9 +19,9 @@
 
 import { css } from '@emotion/react';
 import React from 'react';
-import { Icon } from 'src/Icon';
-import { Typography } from 'src/Typography';
-import useTheme from 'src/utils/useTheme';
+import { Icon } from '../Icon';
+import { Typography } from '../Typography';
+import useTheme from '../utils/useTheme';
 
 const VAlignedText = (props) => (
   <Typography

--- a/src/Pipe/index.tsx
+++ b/src/Pipe/index.tsx
@@ -17,8 +17,8 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { styled } from 'src/ThemeProvider';
-import defaultTheme from 'src/theme/defaultTheme';
+import { styled } from '../ThemeProvider';
+import defaultTheme from '../theme/defaultTheme';
 
 const PipeContainer = styled('div')`
   display: flex;

--- a/src/Progress/index.tsx
+++ b/src/Progress/index.tsx
@@ -18,9 +18,9 @@
  */
 
 import { css } from '@emotion/react';
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../ThemeProvider';
 import React from 'react';
-import { Icon } from 'src/Icon';
+import { Icon } from '../Icon';
 
 export type ProgressStatus = 'success' | 'error' | 'pending' | 'disabled' | 'locked' | 'closed';
 

--- a/src/SubMenu/index.tsx
+++ b/src/SubMenu/index.tsx
@@ -17,11 +17,11 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { CssInterpolation, styled } from 'src/ThemeProvider';
+import { CssInterpolation, styled } from '../ThemeProvider';
 import React from 'react';
-import { Input } from 'src/form/Input';
-import { Icon } from 'src/Icon';
-import useTheme from 'src/utils/useTheme';
+import { Input } from '../form/Input';
+import { Icon } from '../Icon';
+import useTheme from '../utils/useTheme';
 import { ContentContainer, IconContainer, MenuItemContainer } from './styledComponents';
 import { css, Interpolation, Theme } from '@emotion/react';
 

--- a/src/SubMenu/readme.md
+++ b/src/SubMenu/readme.md
@@ -1,6 +1,6 @@
 ### Note:
 
-- `import SubMenu, { MenuItem } from 'src/SubMenu';`
+- `import SubMenu, { MenuItem } from '../SubMenu';`
 - For `MenuItem`, both of the following should work:
   - `<SubMenu.Item />`
   - `<MenuItem />`

--- a/src/SubMenu/styledComponents.tsx
+++ b/src/SubMenu/styledComponents.tsx
@@ -18,8 +18,8 @@
  */
 
 import { css } from '@emotion/react';
-import { styled } from 'src/ThemeProvider';
-import defaultTheme from 'src/theme/defaultTheme';
+import { styled } from '../ThemeProvider';
+import defaultTheme from '../theme/defaultTheme';
 
 type StyleCalculationInput = {
   selected?: boolean;

--- a/src/SystemAlert/index.tsx
+++ b/src/SystemAlert/index.tsx
@@ -1,11 +1,11 @@
 import { css } from '@emotion/react';
 import React from 'react';
-import { Icon } from 'src/Icon';
-import { UikitIconNames } from 'src/Icon/icons';
-import { Link } from 'src/Link';
-import { useTheme } from 'src/ThemeProvider';
-import { Typography } from 'src/Typography';
-import { ThemeColorNames } from 'src/theme/types';
+import { Icon } from '../Icon';
+import { UikitIconNames } from '../Icon/icons';
+import { Link } from '../Link';
+import { useTheme } from '../ThemeProvider';
+import { Typography } from '../Typography';
+import { ThemeColorNames } from '../theme/types';
 
 type AlertLevel = 'error' | 'warning' | 'info';
 

--- a/src/Table/NoDataComponent.tsx
+++ b/src/Table/NoDataComponent.tsx
@@ -19,7 +19,7 @@
 
 import { css } from '@emotion/react';
 import React from 'react';
-import { ContentPlaceholder } from 'src/ContentPlaceholder';
+import { ContentPlaceholder } from '../ContentPlaceholder';
 
 export function NoDataComponent(props) {
   return (

--- a/src/Table/SimpleTable/index.tsx
+++ b/src/Table/SimpleTable/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { css } from '@emotion/react';
-import { Table } from 'src/Table';
+import { Table } from '../../Table';
 
 type MappedTableData = Array<{ key: string; val: any }>;
 

--- a/src/Table/TablePagination/index.tsx
+++ b/src/Table/TablePagination/index.tsx
@@ -18,17 +18,17 @@
  */
 
 import { css } from '@emotion/react';
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../../ThemeProvider';
 import ceil from 'lodash/ceil';
 import floor from 'lodash/floor';
 import range from 'lodash/range';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Select } from 'src/form/Select';
-import { POPUP_POSITIONS } from 'src/form/Select/styledComponents';
-import { Icon } from 'src/Icon';
-import { Typography } from 'src/Typography';
-import useTheme from 'src/utils/useTheme';
+import { Select } from '../../form/Select';
+import { POPUP_POSITIONS } from '../../form/Select/styledComponents';
+import { Icon } from '../../Icon';
+import { Typography } from '../../Typography';
+import useTheme from '../../utils/useTheme';
 
 export const TableActionBar = (props) => {
   const { variant = 'label', color = 'grey', component = 'div' } = props;

--- a/src/Table/index.tsx
+++ b/src/Table/index.tsx
@@ -26,9 +26,9 @@ import selectTable, {
   SelectInputComponentProps,
   SelectTableAdditionalProps,
 } from 'react-table/lib/hoc/selectTable';
-import { DnaLoader } from 'src/DnaLoader';
-import { Checkbox } from 'src/form/Checkbox';
-import { useElementDimension } from 'src/utils/Hook/useElementDimension';
+import { DnaLoader } from '../DnaLoader';
+import { Checkbox } from '../form/Checkbox';
+import { useElementDimension } from '../utils/Hook/useElementDimension';
 import { NoDataComponent as DefaultNoDataComponent } from './NoDataComponent';
 import { StyledTable, StyledTableProps } from './styledComponent';
 import { TablePagination } from './TablePagination';

--- a/src/Table/selectTable.md
+++ b/src/Table/selectTable.md
@@ -1,3 +1,3 @@
 - This SelectTable component is the Table component that has been wrapped with a [selectTable](https://github.com/tannerlinsley/react-table/tree/v6/#selecttable) HOC, with some exension for styling.
 
-- Import: `import { SelectTable } from 'src/Table'`
+- Import: `import { SelectTable } from '../Table'`

--- a/src/Table/styledComponent.tsx
+++ b/src/Table/styledComponent.tsx
@@ -18,14 +18,14 @@
  */
 
 import React from 'react';
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../ThemeProvider';
 import { css } from '@emotion/react';
 import ReactTable from 'react-table';
 
 import reactTableDefaultStyle from './reactTableDefaultStyle';
-import ascending from 'src/assets/table/ascending.svg';
-import descending from 'src/assets/table/descending.svg';
-import unsorted from 'src/assets/table/unsorted.svg';
+import ascending from '../assets/table/ascending.svg';
+import descending from '../assets/table/descending.svg';
+import unsorted from '../assets/table/unsorted.svg';
 
 export type StyledTableProps = {
   withRowBorder?: boolean;

--- a/src/Tabs/index.tsx
+++ b/src/Tabs/index.tsx
@@ -18,10 +18,10 @@
  */
 
 import { css } from '@emotion/react';
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../ThemeProvider';
 import clsx from 'clsx';
 import React from 'react';
-import useTheme from 'src/utils/useTheme';
+import useTheme from '../utils/useTheme';
 
 const TabsContext = React.createContext({ onChange: null, value: null });
 

--- a/src/Tag/index.tsx
+++ b/src/Tag/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { css } from '@emotion/react';
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../ThemeProvider';
 
 type TagVariant =
   | 'DISABLED'

--- a/src/ThemeProvider/index.tsx
+++ b/src/ThemeProvider/index.tsx
@@ -21,7 +21,7 @@ import { Interpolation, ThemeContext, ThemeProvider as EmotionThemeProvider } fr
 import { CreateStyled, default as emotionStyled } from '@emotion/styled';
 import * as React from 'react';
 
-import defaultTheme from 'src/theme/defaultTheme';
+import defaultTheme from '../theme/defaultTheme';
 
 const themes = {
   default: defaultTheme,

--- a/src/TitleBar/index.tsx
+++ b/src/TitleBar/index.tsx
@@ -18,10 +18,10 @@
  */
 
 import { css } from '@emotion/react';
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../ThemeProvider';
 import React from 'react';
-import { Icon } from 'src/Icon';
-import useTheme from 'src/utils/useTheme';
+import { Icon } from '../Icon';
+import useTheme from '../utils/useTheme';
 
 const Nav = styled('nav')`
   padding: 18px 29px 18px 0;

--- a/src/TitleBorder/index.tsx
+++ b/src/TitleBorder/index.tsx
@@ -17,8 +17,8 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { styled } from 'src/ThemeProvider';
-import defaultTheme from 'src/theme/defaultTheme';
+import { styled } from '../ThemeProvider';
+import defaultTheme from '../theme/defaultTheme';
 
 export const TitleBorder = styled('hr')<{
   width?: string;

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -19,11 +19,11 @@
 
 // @flow
 import { css, Global } from '@emotion/react';
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../ThemeProvider';
 import { merge } from 'lodash';
 import * as React from 'react';
 import { Tooltip as ReactTippy, TooltipProps as TippyProps } from 'react-tippy';
-import useTheme from 'src/utils/useTheme';
+import useTheme from '../utils/useTheme';
 
 // exposing full react-tippy API based on https://github.com/tvkhoa/react-tippy
 // extending the html prop to support our previous implementation which also accepted strings

--- a/src/Typography/index.tsx
+++ b/src/Typography/index.tsx
@@ -17,11 +17,11 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../ThemeProvider';
 import memoize from 'lodash/memoize';
 import * as React from 'react';
-import defaultTheme from 'src/theme/defaultTheme';
-import { useTheme } from 'src/ThemeProvider';
+import defaultTheme from '../theme/defaultTheme';
+import { useTheme } from '../ThemeProvider';
 
 const defaultTags = {
   hero: 'h1',

--- a/src/VerticalTabs/index.tsx
+++ b/src/VerticalTabs/index.tsx
@@ -18,13 +18,13 @@
  */
 
 import { css } from '@emotion/react';
-import { styled, useTheme } from 'src/ThemeProvider';
+import { styled, useTheme } from '../ThemeProvider';
 import React, { HTMLAttributes, HtmlHTMLAttributes, MouseEventHandler, ReactNode } from 'react';
-import { FocusWrapper } from 'src/FocusWrapper';
-import { Tag } from 'src/Tag';
-import { Tooltip } from 'src/Tooltip';
-import { Typography } from 'src/Typography';
-import { useElementDimension } from 'src/utils/Hook/useElementDimension';
+import { FocusWrapper } from '../FocusWrapper';
+import { Tag } from '../Tag';
+import { Tooltip } from '../Tooltip';
+import { Typography } from '../Typography';
+import { useElementDimension } from '../utils/Hook/useElementDimension';
 
 type TabStyleType = {
   background: string;

--- a/src/form/Checkbox/index.tsx
+++ b/src/form/Checkbox/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import React, { RefObject } from 'react';
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../../ThemeProvider';
 
 /**
  * Checkbox styles

--- a/src/form/FormCheckbox/index.tsx
+++ b/src/form/FormCheckbox/index.tsx
@@ -19,13 +19,13 @@
 
 import { css } from '@emotion/react';
 import React, { ReactNode, useContext, useRef, useState } from 'react';
-import { Theme } from 'src/ThemeProvider';
-import { Icon } from 'src/Icon';
-import { useTheme } from 'src/ThemeProvider';
-import { Checkbox } from 'src/form/Checkbox';
-import { RadioCheckboxWrapper } from 'src/form/common';
-import { FormControlContext } from 'src/form/FormControl/FormControlContext';
-import { RadioCheckContext } from 'src/form/RadioCheckboxGroup/RadioCheckContext';
+import { Theme } from '../../ThemeProvider';
+import { Icon } from '../../Icon';
+import { useTheme } from '../../ThemeProvider';
+import { Checkbox } from '../../form/Checkbox';
+import { RadioCheckboxWrapper } from '../../form/common';
+import { FormControlContext } from '../../form/FormControl/FormControlContext';
+import { RadioCheckContext } from '../../form/RadioCheckboxGroup/RadioCheckContext';
 
 export const FormCheckbox = ({
   checked,

--- a/src/form/FormHelperText/index.tsx
+++ b/src/form/FormHelperText/index.tsx
@@ -21,8 +21,8 @@ import { css } from '@emotion/react';
 import clsx from 'clsx';
 import pick from 'lodash/pick';
 import React from 'react';
-import { FormControlContext } from 'src/form/FormControl/FormControlContext';
-import { styled } from 'src/ThemeProvider';
+import { FormControlContext } from '../../form/FormControl/FormControlContext';
+import { styled } from '../../ThemeProvider';
 
 export const FormHelperText = React.forwardRef<
   any,

--- a/src/form/FormRadio/index.tsx
+++ b/src/form/FormRadio/index.tsx
@@ -19,9 +19,9 @@
 
 import { css } from '@emotion/react';
 import React, { useContext } from 'react';
-import { RadioCheckboxWrapper } from 'src/form/common';
-import { Radio } from 'src/form/Radio';
-import { RadioCheckContext } from 'src/form/RadioCheckboxGroup/RadioCheckContext';
+import { RadioCheckboxWrapper } from '../../form/common';
+import { Radio } from '../../form/Radio';
+import { RadioCheckContext } from '../../form/RadioCheckboxGroup/RadioCheckContext';
 
 /**
  * FormRadio to be used with RadioCheckboxGroup

--- a/src/form/Input/index.tsx
+++ b/src/form/Input/index.tsx
@@ -19,10 +19,10 @@
 
 import { css } from '@emotion/react';
 import React, { useContext, useState } from 'react';
-import { Button } from 'src/Button';
-import { Icon } from 'src/Icon';
-import { INPUT_SIZES, StyledInputWrapper, StyledInputWrapperProps } from 'src/form/common';
-import { FormControlContext } from 'src/form/FormControl/FormControlContext';
+import { Button } from '../../Button';
+import { Icon } from '../../Icon';
+import { INPUT_SIZES, StyledInputWrapper, StyledInputWrapperProps } from '../../form/common';
+import { FormControlContext } from '../../form/FormControl/FormControlContext';
 import { IconWrapper, StyledInput } from './styledComponents';
 
 type InputPreset = 'default' | 'search';

--- a/src/form/Input/styledComponents.tsx
+++ b/src/form/Input/styledComponents.tsx
@@ -17,9 +17,9 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../../ThemeProvider';
 import { css } from '@emotion/react';
-export { StyledInputWrapper } from 'src/form/common';
+export { StyledInputWrapper } from '../../form/common';
 
 export const StyledInput = styled('input')<{ inputSize: string }>`
   ${({ theme }) => css(theme.typography.default as any)};

--- a/src/form/InputLabel/index.tsx
+++ b/src/form/InputLabel/index.tsx
@@ -18,13 +18,13 @@
  */
 
 import { css } from '@emotion/react';
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../../ThemeProvider';
 import clsx from 'clsx';
 import get from 'lodash/get';
 import pick from 'lodash/pick';
 import React from 'react';
-import { Icon } from 'src/Icon';
-import { FormControlContext } from 'src/form/FormControl/FormControlContext';
+import { Icon } from '../../Icon';
+import { FormControlContext } from '../../form/FormControl/FormControlContext';
 
 export const InputLabel = React.forwardRef<
   HTMLLabelElement,

--- a/src/form/MultiSelect/Option.tsx
+++ b/src/form/MultiSelect/Option.tsx
@@ -19,7 +19,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../../ThemeProvider';
 import { css } from '@emotion/react';
 
 const Li = styled('li')`

--- a/src/form/MultiSelect/index.tsx
+++ b/src/form/MultiSelect/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { css } from '@emotion/react';
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../../ThemeProvider';
 import clsx from 'clsx';
 import compact from 'lodash/compact';
 import find from 'lodash/find';
@@ -31,11 +31,11 @@ import toLower from 'lodash/toLower';
 import uniq from 'lodash/uniq';
 import without from 'lodash/without';
 import React, { InputHTMLAttributes, useEffect } from 'react';
-import { Icon } from 'src/Icon';
-import { Tag } from 'src/Tag';
-import useTheme from 'src/utils/useTheme';
-import { InputSize, INPUT_SIZES, INPUT_STATES, StyledInputWrapper } from 'src/form/common';
-import { FormControlContext } from 'src/form/FormControl/FormControlContext';
+import { Icon } from '../../Icon';
+import { Tag } from '../../Tag';
+import useTheme from '../../utils/useTheme';
+import { InputSize, INPUT_SIZES, INPUT_STATES, StyledInputWrapper } from '../../form/common';
+import { FormControlContext } from '../../form/FormControl/FormControlContext';
 import { Option } from './Option';
 
 const Container = styled('div')<{ focus: boolean }>`

--- a/src/form/Radio/index.tsx
+++ b/src/form/Radio/index.tsx
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { styled } from 'src/ThemeProvider';
+import { styled } from '../../ThemeProvider';
 import React from 'react';
 
 /*

--- a/src/form/RadioCheckboxGroup/RadioCheckContext.tsx
+++ b/src/form/RadioCheckboxGroup/RadioCheckContext.tsx
@@ -18,7 +18,7 @@
  */
 
 import React from 'react';
-import { Checkbox } from 'src/form/Checkbox';
+import { Checkbox } from '../../form/Checkbox';
 
 export const RadioCheckContext = React.createContext<{
   isChecked?: boolean | ((e: any) => boolean);

--- a/src/form/RadioCheckboxGroup/index.tsx
+++ b/src/form/RadioCheckboxGroup/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import React from 'react';
-import { Typography } from 'src/Typography';
+import { Typography } from '../../Typography';
 import { RadioCheckContext } from './RadioCheckContext';
 
 export const RadioCheckboxGroup: React.ComponentType<

--- a/src/form/Select/index.tsx
+++ b/src/form/Select/index.tsx
@@ -19,16 +19,16 @@
 
 import { css } from '@emotion/react';
 import React, { useContext, useEffect, useState } from 'react';
-import { Tooltip } from 'src/Tooltip';
-import { Typography } from 'src/Typography';
-import useTheme from 'src/utils/useTheme';
+import { Tooltip } from '../../Tooltip';
+import { Typography } from '../../Typography';
+import useTheme from '../../utils/useTheme';
 import {
   InputSize,
   INPUT_SIZES,
   StyledInputWrapper,
   StyledInputWrapperProps,
-} from 'src/form/common';
-import { FormControlContext } from 'src/form/FormControl/FormControlContext';
+} from '../../form/common';
+import { FormControlContext } from '../../form/FormControl/FormControlContext';
 import {
   DropdownIcon,
   HiddenSelect,

--- a/src/form/Select/styledComponents.tsx
+++ b/src/form/Select/styledComponents.tsx
@@ -19,9 +19,9 @@
 
 import React from 'react';
 import { withProps } from 'recompose';
-import { Icon } from 'src/Icon';
-import { Typography } from 'src/Typography';
-import { styled } from 'src/ThemeProvider';
+import { Icon } from '../../Icon';
+import { Typography } from '../../Typography';
+import { styled } from '../../ThemeProvider';
 
 export type PopupPosition = 'UP' | 'DOWN';
 export const POPUP_POSITIONS = { UP: 'UP' as PopupPosition, DOWN: 'DOWN' as PopupPosition };

--- a/src/form/Textarea/index.tsx
+++ b/src/form/Textarea/index.tsx
@@ -20,9 +20,9 @@
 import { css } from '@emotion/react';
 import clsx from 'clsx';
 import React, { TextareaHTMLAttributes, useCallback, useContext, useEffect, useState } from 'react';
-import { useTheme } from 'src/ThemeProvider';
-import { Typography } from 'src/Typography';
-import { FormControlContext } from 'src/form/FormControl/FormControlContext';
+import { useTheme } from '../../ThemeProvider';
+import { Typography } from '../../Typography';
+import { FormControlContext } from '../../form/FormControl/FormControlContext';
 import { CountLabels, TextareaProps } from './types';
 
 const LINE_JUMP_PLACEHOLDER = ' øö ';

--- a/src/form/common.tsx
+++ b/src/form/common.tsx
@@ -18,8 +18,8 @@
  */
 
 import { css } from '@emotion/react';
-import { INPUT_STATES as INPUT_THEME_STATES } from 'src/theme/defaultTheme/input';
-import { styled } from 'src/ThemeProvider';
+import { INPUT_STATES as INPUT_THEME_STATES } from '../theme/defaultTheme/input';
+import { styled } from '../ThemeProvider';
 
 export type InputSize = 'sm' | 'lg';
 

--- a/src/notifications/Banner/index.tsx
+++ b/src/notifications/Banner/index.tsx
@@ -23,7 +23,7 @@ import {
   NOTIFICATION_INTERACTION,
   NOTIFICATION_SIZES,
   NOTIFICATION_VARIANTS,
-} from 'src/notifications/Notification';
+} from '../../notifications/Notification';
 
 export const BANNER_VARIANTS = NOTIFICATION_VARIANTS;
 export const BANNER_SIZE = NOTIFICATION_SIZES;

--- a/src/notifications/Notification/index.tsx
+++ b/src/notifications/Notification/index.tsx
@@ -20,11 +20,11 @@
 import { Interpolation, Theme, css } from '@emotion/react';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { UikitIconNames } from 'src/Icon/icons';
-import { FocusWrapper } from 'src/FocusWrapper';
-import { Icon } from 'src/Icon';
-import { Typography, TypographyVariant } from 'src/Typography';
-import useTheme from 'src/utils/useTheme';
+import { UikitIconNames } from '../../Icon/icons';
+import { FocusWrapper } from '../../FocusWrapper';
+import { Icon } from '../../Icon';
+import { Typography, TypographyVariant } from '../../Typography';
+import useTheme from '../../utils/useTheme';
 import {
   ActionButton,
   ActionButtonsContainer,
@@ -33,7 +33,7 @@ import {
   NotificationBodyContainer,
   NotificationContainer,
 } from './styledComponents';
-import { CssInterpolation } from 'src/ThemeProvider';
+import { CssInterpolation } from '../../ThemeProvider';
 
 export type NotificationVariant = 'INFO' | 'SUCCESS' | 'WARNING' | 'ERROR';
 export type NotificationInteractionEvent = 'CLOSE' | 'ACTION' | 'DISMISS';

--- a/src/notifications/Notification/styledComponents.tsx
+++ b/src/notifications/Notification/styledComponents.tsx
@@ -17,8 +17,8 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { styled } from 'src/ThemeProvider';
-import { FocusWrapper } from 'src/FocusWrapper';
+import { styled } from '../../ThemeProvider';
+import { FocusWrapper } from '../../FocusWrapper';
 import { NotificationVariant, NOTIFICATION_VARIANTS } from './index';
 
 const getBackgroundColor = ({ theme, variant }: { theme?: any; variant: NotificationVariant }) =>

--- a/src/notifications/Toast/index.tsx
+++ b/src/notifications/Toast/index.tsx
@@ -23,7 +23,7 @@ import {
   Notification,
   NOTIFICATION_INTERACTION,
   NOTIFICATION_VARIANTS,
-} from 'src/notifications/Notification';
+} from '../../notifications/Notification';
 
 export function Toast({
   variant,

--- a/src/notifications/ToastStack/index.tsx
+++ b/src/notifications/ToastStack/index.tsx
@@ -20,8 +20,8 @@
 import differenceBy from 'lodash/differenceBy';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { styled } from 'src/ThemeProvider';
-import { Toast } from 'src/notifications/Toast';
+import { styled } from '../../ThemeProvider';
+import { Toast } from '../../notifications/Toast';
 
 const usePrevious = (value) => {
   const ref = React.useRef();

--- a/src/theme/defaultTheme/progress.tsx
+++ b/src/theme/defaultTheme/progress.tsx
@@ -18,7 +18,7 @@
  */
 
 import colors from './colors';
-import { ProgressStatus } from 'src/Progress';
+import { ProgressStatus } from '../../Progress';
 
 const color: { [key in ProgressStatus]: string } = {
   success: colors.success,

--- a/src/utils/Hook/useElementDimension.tsx
+++ b/src/utils/Hook/useElementDimension.tsx
@@ -19,7 +19,7 @@
 
 import debounce from 'lodash/debounce';
 import React from 'react';
-import { getElementResizeListener } from 'src/utils/getElementResizeListener';
+import { getElementResizeListener } from '../../utils/getElementResizeListener';
 
 export const useElementDimension = (
   parentRef: React.RefObject<HTMLElement>,

--- a/src/utils/useTheme.tsx
+++ b/src/utils/useTheme.tsx
@@ -17,5 +17,5 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { useTheme } from 'src/ThemeProvider';
+import { useTheme } from '../ThemeProvider';
 export default useTheme;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,15 +14,11 @@
     "isolatedModules": false,
     "jsx": "preserve",
     "jsxImportSource": "@emotion/react",
-    "baseUrl": ".",
     "downlevelIteration": true,
     "outDir": "./dist",
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,
     "declaration": true,
-    "paths": {
-      "src/*": ["./src/*"]
-    },
     "types": ["@emotion/react/types/css-prop"]
   },
   "exclude": [


### PR DESCRIPTION
**Description of changes**

Published UIKit had path issues on the transpiled code. This can be better controlled by removing absolute path resolution in the `tsconfig`. Now all imports from local modules are handled with relative paths.

This also required a change to the `main` and `types` props of `package.json`, which are now declared as being in the same dir (as is the case when the `dist/` dir is published). Note that publishing MUST be done from the `dist/` dir for this all to work as expected.

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature
