### PR TITLE
Platform #2428 - Broken UI for row count display

### DIFF
--- a/src/Table/TablePagination/index.tsx
+++ b/src/Table/TablePagination/index.tsx
@@ -150,6 +150,8 @@ export function TablePagination(props) {
           <div
             css={css`
               transform: scale(0.8);
+              //use z-index to make popup always appear on the top of other components
+              z-index: 10;
             `}
           >
             <Select


### PR DESCRIPTION
Add a high (10) zindex value to the `<div><Select/><div/>` within pagination. This is to ensure that the 'Show # Rows ' popup menu always appears on the top of other components.

**Type of Change**

- [ ] Styling


**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [ ] No new UIKit components or changes
- [ ] Feature is minimally responsive
- [ ] Manual testing of UI feature
- [ ] Add copyrights to new files
- [ ] Connected ticket to PR
