### PR TITLE
Run NPM Publish from `dist` dir

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v2.4.1
         with:
-          node-version: "lts/gallium"
+          node-version: 'lts/gallium'
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -32,10 +32,11 @@ jobs:
       #  run: npm run test
 
       - name: NPM Publish
+        run: cd dist
         uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
-          access: "public"
+          access: 'public'
 
       - name: Git tag
         run: |


### PR DESCRIPTION
**Description of changes**

<!-- Please add a brief description of the changes here: What is the new functionality, how did you accomplish this?-->
Attempting to fix the `release` github action. The npm `publish-uikit` script in the `package.json` runs publishes from the `/dist` dir. Since the github action failed publish but the npm script is successful when run locally, this should make them behave the same way.
