### PR TITLE
Export CellContext from ReactTable

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,7 +27,7 @@ export { default as overtureLogo } from './assets/overture-logo.svg';
 export { default as ThemeProvider, styled } from './ThemeProvider';
 export { default as useTheme } from './utils/useTheme';
 export { default as colors } from './theme/defaultTheme/colors';
-export { ColumnDef, createColumnHelper } from '@tanstack/react-table';
+export { ColumnDef, createColumnHelper, CellContext } from '@tanstack/react-table';
 
 // single point of export ensures lib export works correctly
 export * from './Affix';


### PR DESCRIPTION
**Description of changes**

<!-- Please add a brief description of the changes here: What is the new functionality, how did you accomplish this?-->
Simple use case in ARGO Platform-UI required access to the CellContext type.

It is likely we will need to expose more types from ReactTables in teh future, but after a quick review it is unclear what will be required (and export all is likely too much). There's a possiblilty of exporting them all with a namespace... Will propose this before major version release.

**Type of Change**

- [ ] Bug
- [ ] Styling
- [x] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [x] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [x] No new UIKit components or changes
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [x] Add copyrights to new files
- [ ] Connected ticket to PR
