### PR TITLE
Footer component updates

### DIFF
--- a/src/Footer/index.tsx
+++ b/src/Footer/index.tsx
@@ -19,7 +19,7 @@
 
 /** @jsxImportSource @emotion/react */
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '../ThemeProvider';
 import { Icon } from '../Icon';
@@ -45,14 +45,14 @@ const Container = styled('footer')`
 type FooterLink = { displayName: string } & React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
 type FooterProps = {
-  subtitle: string;
-  links: FooterLink[];
-  className: string;
-  Logo: React.FC;
-  otherProps: any;
+  subtitle?: string;
+  links?: FooterLink[];
+  className?: string;
+  Logo?: ReactNode;
+  otherProps?: any;
 };
 
-const DefaultLogo: React.FC = () => (
+const DefaultLogo = () => (
   <a href="https://www.oicr.on.ca/" target="_blank">
     <img
       alt="Logo for Ontario Institute for Cancer Research"
@@ -66,7 +66,7 @@ export const Footer = ({
   subtitle = '',
   links = [],
   className = '',
-  Logo = DefaultLogo,
+  Logo = <DefaultLogo />,
   ...otherProps
 }: FooterProps) => (
   <Container className={`footer ${className}`} {...otherProps}>
@@ -125,9 +125,7 @@ export const Footer = ({
         </div>
 
         {/** right side logo eg. OICR, RDPC */}
-        <div>
-          <Logo />
-        </div>
+        <div>{Logo}</div>
       </Col>
     </Row>
   </Container>

--- a/src/Footer/index.tsx
+++ b/src/Footer/index.tsx
@@ -30,6 +30,10 @@ import { Link as A } from '../Link';
 
 const Container = styled('footer')`
   ${({ theme }) => css(theme.typography.paragraph as any)};
+  background: #fff;
+  z-index: 1;
+  padding: 0 24px;
+  border-top: 1px solid ${({ theme }) => theme.colors.grey_2};
   font-size: 11px;
   min-height: 58px;
 
@@ -38,13 +42,33 @@ const Container = styled('footer')`
   }
 `;
 
+type FooterLink = { displayName: string } & React.AnchorHTMLAttributes<HTMLAnchorElement>;
+
+type FooterProps = {
+  subtitle: string;
+  links: FooterLink[];
+  className: string;
+  Logo: React.FC;
+  otherProps: any;
+};
+
+const DefaultLogo: React.FC = () => (
+  <a href="https://www.oicr.on.ca/" target="_blank">
+    <img
+      alt="Logo for Ontario Institute for Cancer Research"
+      src={icgcLogo}
+      style={{ height: '42px' }}
+    />
+  </a>
+);
+
 export const Footer = ({
-  version = '[version]',
-  apiVersion = null,
+  subtitle = '',
   links = [],
   className = '',
+  Logo = DefaultLogo,
   ...otherProps
-}) => (
+}: FooterProps) => (
   <Container className={`footer ${className}`} {...otherProps}>
     <Row
       css={css`
@@ -60,10 +84,14 @@ export const Footer = ({
           align-items: center;
         `}
       >
-        © {new Date().getFullYear()} ICGC ARGO. All rights reserved.
-        <br />
-        ICGC ARGO Data Platform {version} {apiVersion && `- API ${apiVersion}`}
+        {/** copyright and ARGO logo */}
+        <div>
+          © {new Date().getFullYear()} ICGC ARGO. All rights reserved.
+          <br />
+          {subtitle}
+        </div>
       </Col>
+
       <Col
         md={7}
         css={css`
@@ -74,6 +102,7 @@ export const Footer = ({
           padding-left: 22px;
         `}
       >
+        {/** nav links */}
         <div>
           {links.map(({ displayName, href, target }, idx) => {
             if (idx !== links.length - 1) {
@@ -95,22 +124,9 @@ export const Footer = ({
           })}
         </div>
 
-        <div
-          css={css`
-            display: flex;
-            align-items: center;
-            flex-direction: row-reverse;
-            line-height: 0;
-            margin-left: 16px;
-          `}
-        >
-          <a href="https://www.oicr.on.ca/" target="_blank">
-            <img
-              alt="Ontario Institute for Cancer Research"
-              src={icgcLogo}
-              style={{ height: '42px' }}
-            />
-          </a>
+        {/** right side logo eg. OICR, RDPC */}
+        <div>
+          <Logo />
         </div>
       </Col>
     </Row>


### PR DESCRIPTION
**Description of changes**

- add types
- clean up styling and add some extra opinionated default styling
- increase reusability 
  - right side `Logo` placeholder is now a slot (use your own component from consumer project)
  - string under copyright is a prop called `subtitle` (useful for any version format, extra info) 
  
  
Extended reasoning:
- it's uikit for we want reusability. currently the smallest deviation will require a new component. eg. [daco](https://daco.icgc-argo.org/) is custom footer even though it's very close in design to `platform-ui`. 

**Type of Change**

- [ ] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [ ] No new UIKit components or changes
- [ ] Feature is minimally responsive
- [ ] Manual testing of UI feature
- [ ] Add copyrights to new files
- [ ] Connected ticket to PR
